### PR TITLE
docs: Improves readability for README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,11 @@ tov -t yaml < input.yaml
 ----------
 
 ## Flags
-
--f, --file input file (defaults to stdin)
--o, --output output file (defaults to stdout)
--t, --type json | yaml | toml | xml (auto-detect if omitted)
+| Flag | Description |
+| --- | --- |
+| -f | --file input file (defaults to stdin) |
+| -o |  --output output file (defaults to stdout) | 
+| -t | --type json \| yaml \| toml \| xml (auto-detect if omitted) | 
 
 ----------
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # tov
-
-Convert JSON, YAML, TOML or XML into V structs.
+Convert JSON, YAML, TOML or XML into **V structs**.
 
 No UI.
+
 No magic.
-Just structs.
+
+Just **structs**.
 
 ---
 
@@ -14,7 +15,6 @@ Just structs.
 git clone https://github.com/seu-usuario/tov.git
 cd tov
 v -prod -cflags "-s" .
-
 ```
 
 ----------
@@ -25,7 +25,6 @@ v -prod -cflags "-s" .
 tov -f input.json -o output.v
 cat input.json | tov -o output.v
 tov -t yaml < input.yaml
-
 ```
 
 ----------
@@ -40,7 +39,6 @@ tov -t yaml < input.yaml
 ----------
 
 ## Example
-
 ```json
 {
   "name": "John",
@@ -79,4 +77,12 @@ struct Root {
 
 ----------
 
-Apache-2.0
+## Contributing
+
+[Contribution guide](CONTRIBUTING.md)
+
+----------
+
+## Licence
+
+[Apache-2.0](LICENSE)


### PR DESCRIPTION
At the "Flags" section in README.md, there is a hard to read presentation of the accepted flags for tov.
This merge searches to improve the readability by formatting the flags into a table and benefits the file with quick shortcuts for important documents for the project.